### PR TITLE
Fix bugs

### DIFF
--- a/lib/time_difference.rb
+++ b/lib/time_difference.rb
@@ -124,9 +124,16 @@ class TimeDifference
   end
 
   def set_partial_months
-    first_month_days = @months_array[@start_time.month - 1] - @start_time.day
-    @months += (first_month_days.to_f / @months_array[@start_time.month - 1].to_f)
-    @months += (@end_time.day.to_f / @months_array[@end_time.month - 1].to_f)
+    if @end_time.day > @start_time.day
+      @months += 1
+      remaining_days = @end_time.day - @start_time.day
+      @months += (remaining_days.to_f / @months_array[@end_time.month - 1].to_f)
+    else
+      first_month_days = @months_array[@start_time.month - 1] - @start_time.day
+      @months += (first_month_days.to_f / @months_array[@start_time.month - 1].to_f)
+      @months += (@end_time.day.to_f / @months_array[@end_time.month - 1].to_f)
+    end
+
   end
 
   def set_same_month_months

--- a/lib/time_difference.rb
+++ b/lib/time_difference.rb
@@ -124,16 +124,18 @@ class TimeDifference
   end
 
   def set_partial_months
-    if @end_time.day > @start_time.day
-      @months += 1
-      remaining_days = @end_time.day - @start_time.day
-      @months += (remaining_days.to_f / @months_array[@end_time.month - 1].to_f)
-    else
-      first_month_days = @months_array[@start_time.month - 1] - @start_time.day
-      @months += (first_month_days.to_f / @months_array[@start_time.month - 1].to_f)
-      @months += (@end_time.day.to_f / @months_array[@end_time.month - 1].to_f)
-    end
+    @end_time.day > @start_time.day ? set_partial_month_of_greater_than_one : set_partial_month_of_less_than_one
+  end
 
+  def set_partial_month_of_greater_than_one
+    @months += 1
+    @months += ((@end_time.day - @start_time.day).to_f / @months_array[@end_time.month - 1].to_f)
+  end
+
+  def set_partial_month_of_less_than_one
+    first_month_days = @months_array[@start_time.month - 1] - @start_time.day
+    @months += (first_month_days.to_f / @months_array[@start_time.month - 1].to_f)
+    @months += (@end_time.day.to_f / @months_array[@end_time.month - 1].to_f)
   end
 
   def set_same_month_months

--- a/lib/time_difference.rb
+++ b/lib/time_difference.rb
@@ -18,58 +18,8 @@ class TimeDifference
   def in_months
     @months = 0.0
     @start_time, @end_time = @end_time, @start_time if @end_time < @start_time
-
-    if @end_time.year - @start_time.year >= 1
-      first_year_months((((@start_time + 1.year).at_beginning_of_year - @start_time) / 86400) - 1)
-      last_year_months(((@end_time - @end_time.at_beginning_of_year) / 86400 + 1))
-      @months += ((@end_time.year - @start_time.year) - 1) * 12 if @end_time.year - @start_time.year >= 2
-    elsif (@end_time.year - @start_time.year).zero? && @end_time.month != @start_time.month
-      set_months_array(@start_time)
-      if @start_time.day == @end_time.day
-        @months += 1
-      else
-        first_month_days = @months_array[@start_time.month - 1] - @start_time.day
-        @months += (first_month_days.to_f / @months_array[@start_time.month - 1].to_f)
-        @months += (@end_time.day.to_f / @months_array[@end_time.month - 1].to_f)
-      end
-      @months += (@end_time.month - @start_time.month) - 1
-    elsif (@end_time.year - @start_time.year).zero? && @end_time.month == @start_time.month
-      set_months_array(@start_time)
-      @months += (@end_time.day - @start_time.day).to_f / @months_array[@start_time.month - 1.to_f]
-    end
+    @end_time.year - @start_time.year >= 1 ? set_multiple_year_months : (@end_time.month != @start_time.month ? set_same_year_months : set_same_month_months)
     @months.round(2)
-  end
-
-  def first_year_months(days)
-    set_months_array(@start_time)
-    @months_array.reverse.each do |month_days|
-      break if days <= 0
-
-      days < month_days ? @months += (days / month_days) : @months += 1
-      days -= month_days
-    end
-  end
-
-  def last_year_months(days)
-    set_months_array(@end_time)
-    @months_array.each do |month_days|
-      break if days <= 0
-
-      days < month_days ? @months += (days / month_days) : @months += 1
-      days -= month_days
-    end
-  end
-
-  def set_months_array(time_to_set)
-    @months_array = time_to_set.to_date.leap? ? leap_year_months : normal_year_months
-  end
-
-  def normal_year_months
-    [31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31]
-  end
-
-  def leap_year_months
-    [31, 29, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31]
   end
 
   def in_weeks
@@ -119,7 +69,7 @@ class TimeDifference
     end_time_in_seconds = time_in_seconds(end_time)
 
     @time_diff = (end_time_in_seconds - start_time_in_seconds).abs
-    @time_diff += 86400 if include_leap_year_day?(start_time, end_time)
+    # @time_diff += 86400 if include_leap_year_day?(start_time, end_time)
   end
 
   def time_in_seconds(time)
@@ -130,10 +80,73 @@ class TimeDifference
     (@time_diff / 1.send(component)).round(2)
   end
 
-  def include_leap_year_day?(start_date, end_date)
-    start_date = start_date.to_date
-    end_date = end_date.to_date
-    (start_date..end_date).select{ |date| date.month == 2 && date.day > 28 }.any? && in_days >= 1.0
+  def set_multiple_year_months
+    first_year_months(first_year_days)
+    last_year_months(last_year_days)
+    @months += ((@end_time.year - @start_time.year) - 1) * 12 if @end_time.year - @start_time.year >= 2
   end
+
+  def first_year_months(days)
+    set_months_array(@start_time)
+    @months_array.reverse.each do |month_days|
+      break if days <= 0
+
+      days < month_days ? @months += (days / month_days) : @months += 1
+      days -= month_days
+    end
+  end
+
+  def last_year_months(days)
+    set_months_array(@end_time)
+    @months_array.each do |month_days|
+      break if days <= 0
+
+      days < month_days ? @months += (days / month_days) : @months += 1
+      days -= month_days
+    end
+  end
+
+  def first_year_days
+    (((@start_time + 1.year).at_beginning_of_year - @start_time) / 86400) - 1
+  end
+
+  def last_year_days
+    ((@end_time - @end_time.at_beginning_of_year) / 86400 + 1)
+  end
+
+  def set_same_year_months
+    set_months_array(@start_time)
+    @start_time.day == @end_time.day ? @months += 1 : set_partial_months
+    @months += (@end_time.month - @start_time.month) - 1
+  end
+
+  def set_partial_months
+    first_month_days = @months_array[@start_time.month - 1] - @start_time.day
+    @months += (first_month_days.to_f / @months_array[@start_time.month - 1].to_f)
+    @months += (@end_time.day.to_f / @months_array[@end_time.month - 1].to_f)
+  end
+
+  def set_same_month_months
+    set_months_array(@start_time)
+    @months += (@end_time.day - @start_time.day).to_f / @months_array[@start_time.month - 1.to_f]
+  end
+
+  def set_months_array(time_to_set)
+    @months_array = time_to_set.to_date.leap? ? leap_year_months : normal_year_months
+  end
+
+  def normal_year_months
+    [31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31]
+  end
+
+  def leap_year_months
+    [31, 29, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31]
+  end
+
+  # def include_leap_year_day?(start_date, end_date)
+  #   start_date = start_date.to_date
+  #   end_date = end_date.to_date
+  #   (start_date..end_date).select{ |date| date.month == 2 && date.day > 28 }.any? && in_days >= 1.0
+  # end
 
 end

--- a/lib/time_difference.rb
+++ b/lib/time_difference.rb
@@ -69,7 +69,6 @@ class TimeDifference
     end_time_in_seconds = time_in_seconds(end_time)
 
     @time_diff = (end_time_in_seconds - start_time_in_seconds).abs
-    # @time_diff += 86400 if include_leap_year_day?(start_time, end_time)
   end
 
   def time_in_seconds(time)
@@ -142,11 +141,4 @@ class TimeDifference
   def leap_year_months
     [31, 29, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31]
   end
-
-  # def include_leap_year_day?(start_date, end_date)
-  #   start_date = start_date.to_date
-  #   end_date = end_date.to_date
-  #   (start_date..end_date).select{ |date| date.month == 2 && date.day > 28 }.any? && in_days >= 1.0
-  # end
-
 end

--- a/lib/time_difference.rb
+++ b/lib/time_difference.rb
@@ -18,7 +18,7 @@ class TimeDifference
   def in_months
     @months = 0.0
     @start_time, @end_time = @end_time, @start_time if @end_time < @start_time
-    @end_time.year - @start_time.year >= 1 ? set_multiple_year_months : (@end_time.month != @start_time.month ? set_same_year_months : set_same_month_months)
+    @end_time.year - @start_time.year >= 1 ? set_multiple_year_months : set_single_year_months
     @months.round(2)
   end
 
@@ -113,7 +113,11 @@ class TimeDifference
     ((@end_time - @end_time.at_beginning_of_year) / 86400 + 1)
   end
 
-  def set_same_year_months
+  def set_single_year_months
+    @end_time.month != @start_time.month ? set_different_month_months : set_same_month_months
+  end
+
+  def set_different_month_months
     set_months_array(@start_time)
     @start_time.day == @end_time.day ? @months += 1 : set_partial_months
     @months += (@end_time.month - @start_time.month) - 1

--- a/lib/time_difference.rb
+++ b/lib/time_difference.rb
@@ -17,59 +17,72 @@ class TimeDifference
 
   def in_months
     # (@time_diff / (1.day * 30.42)).round(2)
-    months = 0
+
+    @months = 0.0
     @start_time, @end_time = @end_time, @start_time if @end_time < @start_time
 
     if @end_time.year - @start_time.year >= 1
-      first_year_days = ((@start_time + 1.year).at_beginning_of_year - @start_time) / 86400
+      first_year_days = (((@start_time + 1.year).at_beginning_of_year - @start_time) / 86400) - 1
       first_year_months(first_year_days)
 
-      last_year_days = (@end_time - @end_time.at_beginning_of_year) / 86400
+      last_year_days = ((@end_time - @end_time.at_beginning_of_year) / 86400 + 1)
       last_year_months(last_year_days)
 
-      months += (@end_time.year - @start_time.year) * 12 if @end_time.year - @start_time.year >= 2
+      @months += (@end_time.year - @start_time.year) * 12 if @end_time.year - @start_time.year >= 2
     elsif (@end_time.year - @start_time.year).zero? && @end_time.month != @start_time.month
       if @start_time.to_date.leap?
-        first_month_days = leap_year_months[@start_time.month - 1] - @start_time.day
-        months += (first_month_days / leap_year_months[@start_time.month - 1])
+        if @start_time.day == @end_time.day
+          @months += 1
+        else
+          first_month_days = leap_year_months[@start_time.month - 1] - @start_time.day
+          @months += (first_month_days.to_f / leap_year_months[@start_time.month - 1].to_f)
+          @months += (@end_time.day.to_f / leap_year_months[@end_time.month - 1].to_f)
+        end
 
-        months += (@end_time.day / leap_year_months[@end_time.month - 1])
-
-        months += (@end_time.month - @start_time.month) - 1
+        @months += (@end_time.month - @start_time.month) - 1
       else
-        first_month_days = normal_year_months[@start_time.month - 1] - @start_time.day
-        months += (first_month_days / normal_year_months[@start_time.month - 1])
+        if @start_time.day == @end_time.day
+          @months += 1
+        else
+          first_month_days = normal_year_months[@start_time.month - 1] - @start_time.day
+          @months += (first_month_days.to_f / normal_year_months[@start_time.month - 1].to_f)
+          @months += (@end_time.day.to_f / normal_year_months[@end_time.month - 1].to_f)
+        end
 
-        months += (@end_time.day / normal_year_months[@end_time.month - 1])
-
-        months += (@end_time.month - @start_time.month) - 1
+        @months += (@end_time.month - @start_time.month) - 1
       end
     elsif (@end_time.year - @start_time.year).zero? && @end_time.month == @start_time.month
       if @start_time.to_date.leap?
-        months += (@end_time.day - @start_time.day) / leap_year_months[@start_time.month - 1]
+        @months += (@end_time.day - @start_time.day) / leap_year_months[@start_time.month - 1]
       else
-        months += (@end_time.day - @start_time.day) / normal_year_months[@start_time.month - 1]
+        @months += (@end_time.day - @start_time.day) / normal_year_months[@start_time.month - 1]
       end
+    else
+      puts "❌❌❌❌❌❌❌❌❌❌❌❌❌"
     end
-    months
+    @months
   end
 
   def first_year_months(days)
     if @start_time.to_date.leap?
       leap_year_months.reverse.each do |month_days|
+        break if days <= 0
+
         if days < month_days
-          months += (days / month_days)
+          @months += (days / month_days)
         else
-          months += 1
+          @months += 1
         end
         days -= month_days
       end
     else
       normal_year_months.reverse.each do |month_days|
+        break if days <= 0
+
         if days < month_days
-          months += (days / month_days)
+          @months += (days / month_days)
         else
-          months += 1
+          @months += 1
         end
         days -= month_days
       end
@@ -79,18 +92,25 @@ class TimeDifference
   def last_year_months(days)
     if @end_time.to_date.leap?
       leap_year_months.each do |month_days|
+        break if days <= 0
+
         if days < month_days
-          months += (days / month_days)
+          @months += (days / month_days)
         else
-          months += 1
+          @months += 1
         end
+        days -= month_days
+      end
     else
       normal_year_months.each do |month_days|
+        break if days <= 0
+
         if days < month_days
-          months += (days / month_days)
+          @months += (days / month_days)
         else
-          months += 1
+          @months += 1
         end
+        days -= month_days
       end
     end
   end

--- a/lib/time_difference.rb
+++ b/lib/time_difference.rb
@@ -16,95 +16,52 @@ class TimeDifference
   end
 
   def in_months
-    # (@time_diff / (1.day * 30.42)).round(2)
-
     @months = 0.0
     @start_time, @end_time = @end_time, @start_time if @end_time < @start_time
 
     if @end_time.year - @start_time.year >= 1
-      first_year_days = (((@start_time + 1.year).at_beginning_of_year - @start_time) / 86400) - 1
-      first_year_months(first_year_days)
-
-      last_year_days = ((@end_time - @end_time.at_beginning_of_year) / 86400 + 1)
-      last_year_months(last_year_days)
-
+      first_year_months((((@start_time + 1.year).at_beginning_of_year - @start_time) / 86400) - 1)
+      last_year_months(((@end_time - @end_time.at_beginning_of_year) / 86400 + 1))
       @months += ((@end_time.year - @start_time.year) - 1) * 12 if @end_time.year - @start_time.year >= 2
     elsif (@end_time.year - @start_time.year).zero? && @end_time.month != @start_time.month
-      if @start_time.to_date.leap?
-        if @start_time.day == @end_time.day
-          @months += 1
-        else
-          first_month_days = leap_year_months[@start_time.month - 1] - @start_time.day
-          @months += (first_month_days.to_f / leap_year_months[@start_time.month - 1].to_f)
-          @months += (@end_time.day.to_f / leap_year_months[@end_time.month - 1].to_f)
-        end
-
-        @months += (@end_time.month - @start_time.month) - 1
+      set_months_array(@start_time)
+      if @start_time.day == @end_time.day
+        @months += 1
       else
-        if @start_time.day == @end_time.day
-          @months += 1
-        else
-          first_month_days = normal_year_months[@start_time.month - 1] - @start_time.day
-          @months += (first_month_days.to_f / normal_year_months[@start_time.month - 1].to_f)
-          @months += (@end_time.day.to_f / normal_year_months[@end_time.month - 1].to_f)
-        end
-
-        @months += (@end_time.month - @start_time.month) - 1
+        first_month_days = @months_array[@start_time.month - 1] - @start_time.day
+        @months += (first_month_days.to_f / @months_array[@start_time.month - 1].to_f)
+        @months += (@end_time.day.to_f / @months_array[@end_time.month - 1].to_f)
       end
+      @months += (@end_time.month - @start_time.month) - 1
     elsif (@end_time.year - @start_time.year).zero? && @end_time.month == @start_time.month
-      if @start_time.to_date.leap?
-        @months += (@end_time.day - @start_time.day).to_f / leap_year_months[@start_time.month - 1.to_f]
-      else
-        @months += (@end_time.day - @start_time.day).to_f / normal_year_months[@start_time.month - 1.to_f]
-      end
-    else
-      puts "❌❌❌❌❌❌❌❌❌❌❌❌❌"
+      set_months_array(@start_time)
+      @months += (@end_time.day - @start_time.day).to_f / @months_array[@start_time.month - 1.to_f]
     end
-    @months
+    @months.round(2)
   end
 
   def first_year_months(days)
-    if @start_time.to_date.leap?
-      leap_year_months.reverse.each do |month_days|
-        break if days <= 0
+    set_months_array(@start_time)
+    @months_array.reverse.each do |month_days|
+      break if days <= 0
 
-        if days < month_days
-          @months += (days / month_days)
-        else
-          @months += 1
-        end
-        days -= month_days
-      end
-    else
-      normal_year_months.reverse.each do |month_days|
-        break if days <= 0
-
-        if days < month_days
-          @months += (days / month_days)
-        else
-          @months += 1
-        end
-        days -= month_days
-      end
+      days < month_days ? @months += (days / month_days) : @months += 1
+      days -= month_days
     end
   end
 
   def last_year_months(days)
-    if @end_time.to_date.leap?
-      leap_year_months.each do |month_days|
-        break if days <= 0
+    set_months_array(@end_time)
+    @months_array.each do |month_days|
+      break if days <= 0
 
-        days < month_days ? @months += (days / month_days) : @months += 1
-        days -= month_days
-      end
-    else
-      normal_year_months.each do |month_days|
-        break if days <= 0
-
-        days < month_days ? @months += (days / month_days) : @months += 1
-        days -= month_days
-      end
+      days < month_days ? @months += (days / month_days) : @months += 1
+      days -= month_days
     end
+  end
+
+  def set_months_array(time_to_set)
+    @months_array = time_to_set.to_date.leap? ? leap_year_months : normal_year_months
   end
 
   def normal_year_months

--- a/lib/time_difference.rb
+++ b/lib/time_difference.rb
@@ -28,7 +28,7 @@ class TimeDifference
       last_year_days = ((@end_time - @end_time.at_beginning_of_year) / 86400 + 1)
       last_year_months(last_year_days)
 
-      @months += (@end_time.year - @start_time.year) * 12 if @end_time.year - @start_time.year >= 2
+      @months += ((@end_time.year - @start_time.year) - 1) * 12 if @end_time.year - @start_time.year >= 2
     elsif (@end_time.year - @start_time.year).zero? && @end_time.month != @start_time.month
       if @start_time.to_date.leap?
         if @start_time.day == @end_time.day
@@ -53,9 +53,9 @@ class TimeDifference
       end
     elsif (@end_time.year - @start_time.year).zero? && @end_time.month == @start_time.month
       if @start_time.to_date.leap?
-        @months += (@end_time.day - @start_time.day) / leap_year_months[@start_time.month - 1]
+        @months += (@end_time.day - @start_time.day).to_f / leap_year_months[@start_time.month - 1.to_f]
       else
-        @months += (@end_time.day - @start_time.day) / normal_year_months[@start_time.month - 1]
+        @months += (@end_time.day - @start_time.day).to_f / normal_year_months[@start_time.month - 1.to_f]
       end
     else
       puts "❌❌❌❌❌❌❌❌❌❌❌❌❌"
@@ -94,22 +94,14 @@ class TimeDifference
       leap_year_months.each do |month_days|
         break if days <= 0
 
-        if days < month_days
-          @months += (days / month_days)
-        else
-          @months += 1
-        end
+        days < month_days ? @months += (days / month_days) : @months += 1
         days -= month_days
       end
     else
       normal_year_months.each do |month_days|
         break if days <= 0
 
-        if days < month_days
-          @months += (days / month_days)
-        else
-          @months += 1
-        end
+        days < month_days ? @months += (days / month_days) : @months += 1
         days -= month_days
       end
     end

--- a/lib/time_difference.rb
+++ b/lib/time_difference.rb
@@ -16,7 +16,91 @@ class TimeDifference
   end
 
   def in_months
-    (@time_diff / (1.day * 30.42)).round(2)
+    # (@time_diff / (1.day * 30.42)).round(2)
+    months = 0
+    @start_time, @end_time = @end_time, @start_time if @end_time < @start_time
+
+    if @end_time.year - @start_time.year >= 1
+      first_year_days = ((@start_time + 1.year).at_beginning_of_year - @start_time) / 86400
+      first_year_months(first_year_days)
+
+      last_year_days = (@end_time - @end_time.at_beginning_of_year) / 86400
+      last_year_months(last_year_days)
+
+      months += (@end_time.year - @start_time.year) * 12 if @end_time.year - @start_time.year >= 2
+    elsif (@end_time.year - @start_time.year).zero? && @end_time.month != @start_time.month
+      if @start_time.to_date.leap?
+        first_month_days = leap_year_months[@start_time.month - 1] - @start_time.day
+        months += (first_month_days / leap_year_months[@start_time.month - 1])
+
+        months += (@end_time.day / leap_year_months[@end_time.month - 1])
+
+        months += (@end_time.month - @start_time.month) - 1
+      else
+        first_month_days = normal_year_months[@start_time.month - 1] - @start_time.day
+        months += (first_month_days / normal_year_months[@start_time.month - 1])
+
+        months += (@end_time.day / normal_year_months[@end_time.month - 1])
+
+        months += (@end_time.month - @start_time.month) - 1
+      end
+    elsif (@end_time.year - @start_time.year).zero? && @end_time.month == @start_time.month
+      if @start_time.to_date.leap?
+        months += (@end_time.day - @start_time.day) / leap_year_months[@start_time.month - 1]
+      else
+        months += (@end_time.day - @start_time.day) / normal_year_months[@start_time.month - 1]
+      end
+    end
+    months
+  end
+
+  def first_year_months(days)
+    if @start_time.to_date.leap?
+      leap_year_months.reverse.each do |month_days|
+        if days < month_days
+          months += (days / month_days)
+        else
+          months += 1
+        end
+        days -= month_days
+      end
+    else
+      normal_year_months.reverse.each do |month_days|
+        if days < month_days
+          months += (days / month_days)
+        else
+          months += 1
+        end
+        days -= month_days
+      end
+    end
+  end
+
+  def last_year_months(days)
+    if @end_time.to_date.leap?
+      leap_year_months.each do |month_days|
+        if days < month_days
+          months += (days / month_days)
+        else
+          months += 1
+        end
+    else
+      normal_year_months.each do |month_days|
+        if days < month_days
+          months += (days / month_days)
+        else
+          months += 1
+        end
+      end
+    end
+  end
+
+  def normal_year_months
+    [31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31]
+  end
+
+  def leap_year_months
+    [31, 29, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31]
   end
 
   def in_weeks
@@ -59,6 +143,9 @@ class TimeDifference
   private
 
   def initialize(start_time, end_time)
+    @start_time = start_time.to_time
+    @end_time = end_time.to_time
+
     start_time_in_seconds = time_in_seconds(start_time)
     end_time_in_seconds = time_in_seconds(end_time)
 

--- a/spec/time_difference_spec.rb
+++ b/spec/time_difference_spec.rb
@@ -334,7 +334,7 @@ describe TimeDifference do
 
             it 'returns 0.5' do
               start_time = clazz.new(2019, 4, 1)
-              end_time = clazz.new(2019, 4, 15)
+              end_time = clazz.new(2019, 4, 16)
 
               expect(TimeDifference.between(start_time, end_time).in_months.round(2)).to eql(0.5)
             end
@@ -343,21 +343,21 @@ describe TimeDifference do
               start_time = clazz.new(2019, 4, 1)
               end_time = clazz.new(2019, 4, 30)
 
-              expect(TimeDifference.between(start_time, end_time).in_months.round(2)).to eql(0.97)
+              expect(TimeDifference.between(start_time, end_time).in_months).to eql(0.97)
             end
 
             it 'returns 0.33' do
               start_time = clazz.new(2019, 4, 1)
               end_time = clazz.new(2019, 4, 11)
 
-              expect(TimeDifference.between(start_time, end_time).in_months.round(2)).to eql(0.33)
+              expect(TimeDifference.between(start_time, end_time).in_months).to eql(0.33)
             end
 
             it '1st to 28th February returns 0.96' do
               start_time = clazz.new(2019, 2, 1)
               end_time = clazz.new(2019, 2, 28)
 
-              expect(TimeDifference.between(start_time, end_time).in_months.round(2)).to eql(0.96)
+              expect(TimeDifference.between(start_time, end_time).in_months).to eql(0.96)
             end
           end
 
@@ -366,14 +366,14 @@ describe TimeDifference do
               start_time = clazz.new(2020, 2, 1)
               end_time = clazz.new(2020, 2, 28)
 
-              expect(TimeDifference.between(start_time, end_time).in_months.round(2)).to eql(0.93)
+              expect(TimeDifference.between(start_time, end_time).in_months).to eql(0.93)
             end
 
             it '1st to 29th February returns 0.97' do
               start_time = clazz.new(2020, 2, 1)
               end_time = clazz.new(2020, 2, 29)
 
-              expect(TimeDifference.between(start_time, end_time).in_months.round(2)).to eql(0.97)
+              expect(TimeDifference.between(start_time, end_time).in_months).to eql(0.97)
             end
           end
         end

--- a/spec/time_difference_spec.rb
+++ b/spec/time_difference_spec.rb
@@ -27,7 +27,7 @@ describe TimeDifference do
         start_time = clazz.new(2011, 1)
         end_time = clazz.new(2011, 12)
 
-        expect(TimeDifference.between(start_time, end_time).in_each_component).to eql({years: 0.91, months: 10.98, weeks: 47.71, days: 334.0, hours: 8016.0, minutes: 480960.0, seconds: 28857600.0})
+        expect(TimeDifference.between(start_time, end_time).in_each_component).to eql({years: 0.91, months: 11.0, weeks: 47.71, days: 334.0, hours: 8016.0, minutes: 480960.0, seconds: 28857600.0})
       end
     end
   end

--- a/spec/time_difference_spec.rb
+++ b/spec/time_difference_spec.rb
@@ -184,42 +184,64 @@ describe TimeDifference do
 
       context 'start_date and end_date are on different days of different months of the same year' do
         context 'start_time is before end_time' do
-          context 'not a leap year' do
-            it 'returns 2.5' do
-              start_time = clazz.new(2019, 1, 1)
-              end_time = clazz.new(2019, 3, 16)
+          context 'start_time.day is < end_time.day' do
+            context 'not a leap year' do
+              it 'returns 2.5' do
+                start_time = clazz.new(2019, 1, 1)
+                end_time = clazz.new(2019, 3, 16)
 
-              expect(TimeDifference.between(start_time, end_time).in_months.round(1)).to eql(2.5)
+                expect(TimeDifference.between(start_time, end_time).in_months.round(1)).to eql(2.5)
+              end
+
+              it 'returns 2.5' do
+                start_time = clazz.new(2019, 4, 10)
+                end_time = clazz.new(2019, 6, 26)
+
+                expect(TimeDifference.between(start_time, end_time).in_months.round(1)).to eql(2.5)
+              end
+
+              it 'returns 5.5' do
+                start_time = clazz.new(2019, 4, 15)
+                end_time = clazz.new(2019, 9, 30)
+
+                expect(TimeDifference.between(start_time, end_time).in_months.round(1)).to eql(5.5)
+              end
             end
 
-            it 'returns 2.5' do
-              start_time = clazz.new(2019, 4, 10)
-              end_time = clazz.new(2019, 6, 26)
+            context 'leap year' do
+              it 'returns 2.5' do
+                start_time = clazz.new(2020, 1, 1)
+                end_time = clazz.new(2020, 3, 16)
 
-              expect(TimeDifference.between(start_time, end_time).in_months.round(1)).to eql(2.5)
-            end
+                expect(TimeDifference.between(start_time, end_time).in_months.round(1)).to eql(2.5)
+              end
 
-            it 'returns 5.5' do
-              start_time = clazz.new(2019, 4, 15)
-              end_time = clazz.new(2019, 9, 30)
+              it 'returns 5.5' do
+                start_time = clazz.new(2020, 4, 15)
+                end_time = clazz.new(2020, 9, 30)
 
-              expect(TimeDifference.between(start_time, end_time).in_months.round(1)).to eql(5.5)
+                expect(TimeDifference.between(start_time, end_time).in_months.round(1)).to eql(5.5)
+              end
             end
           end
 
-          context 'leap year' do
-            it 'returns 2.5' do
-              start_time = clazz.new(2020, 1, 1)
-              end_time = clazz.new(2020, 3, 16)
+          context 'start_time.day is > end_time.day' do
+            context 'normal year' do
+              it 'returns 1.03' do
+                start_time = clazz.new(2019, 2, 15)
+                end_time = clazz.new(2019, 3, 16)
 
-              expect(TimeDifference.between(start_time, end_time).in_months.round(1)).to eql(2.5)
+                expect(TimeDifference.between(start_time, end_time).in_months.round(2)).to eql(1.03)
+              end
             end
 
-            it 'returns 5.5' do
-              start_time = clazz.new(2020, 4, 15)
-              end_time = clazz.new(2020, 9, 30)
+            context 'leap year' do
+              it 'returns 1.03' do
+                start_time = clazz.new(2020, 2, 15)
+                end_time = clazz.new(2020, 3, 16)
 
-              expect(TimeDifference.between(start_time, end_time).in_months.round(1)).to eql(5.5)
+                expect(TimeDifference.between(start_time, end_time).in_months.round(2)).to eql(1.03)
+              end
             end
           end
         end

--- a/spec/time_difference_spec.rb
+++ b/spec/time_difference_spec.rb
@@ -182,6 +182,69 @@ describe TimeDifference do
         end
       end
 
+      context 'start_date and end_date are on different days of different months of the same year' do
+        context 'start_time is before end_time' do
+          context 'not a leap year' do
+            it 'returns 2.5' do
+              start_time = clazz.new(2019, 1, 1)
+              end_time = clazz.new(2019, 3, 16)
+
+              expect(TimeDifference.between(start_time, end_time).in_months.round(1)).to eql(2.5)
+            end
+
+            it 'returns 2.5' do
+              start_time = clazz.new(2019, 4, 10)
+              end_time = clazz.new(2019, 6, 26)
+
+              expect(TimeDifference.between(start_time, end_time).in_months.round(1)).to eql(2.5)
+            end
+
+            it 'returns 5.5' do
+              start_time = clazz.new(2019, 4, 15)
+              end_time = clazz.new(2019, 9, 30)
+
+              expect(TimeDifference.between(start_time, end_time).in_months.round(1)).to eql(5.5)
+            end
+          end
+
+          context 'leap year' do
+            it 'returns 2.5' do
+              start_time = clazz.new(2020, 1, 1)
+              end_time = clazz.new(2020, 3, 16)
+
+              expect(TimeDifference.between(start_time, end_time).in_months.round(1)).to eql(2.5)
+            end
+
+            it 'returns 5.5' do
+              start_time = clazz.new(2020, 4, 15)
+              end_time = clazz.new(2020, 9, 30)
+
+              expect(TimeDifference.between(start_time, end_time).in_months.round(1)).to eql(5.5)
+            end
+          end
+        end
+
+        context 'end_time is before start_time' do
+          context 'not a leap year' do
+            it 'returns 2.5' do
+              start_time = clazz.new(2019, 3, 16)
+              end_time = clazz.new(2019, 1, 1)
+
+              expect(TimeDifference.between(start_time, end_time).in_months.round(1)).to eql(2.5)
+            end
+          end
+
+          context 'leap year' do
+            it 'returns 5.5' do
+              start_time = clazz.new(2020, 9, 30)
+              end_time = clazz.new(2020, 4, 15)
+
+              expect(TimeDifference.between(start_time, end_time).in_months.round(1)).to eql(5.5)
+            end
+          end
+        end
+      end
+
       context 'start_time and end_time are in different years' do
         context 'start_time is before end_time' do
           context 'does not include a leap year' do
@@ -197,6 +260,13 @@ describe TimeDifference do
               end_time = clazz.new(2019, 9, 15)
 
               expect(TimeDifference.between(start_time, end_time).in_months.round(1)).to eql(18.0)
+            end
+
+            it 'returns 18.5' do
+              start_time = clazz.new(2018, 3, 15)
+              end_time = clazz.new(2019, 9, 30)
+
+              expect(TimeDifference.between(start_time, end_time).in_months.round(1)).to eql(18.5)
             end
 
             it 'returns 24.0' do
@@ -227,6 +297,13 @@ describe TimeDifference do
               end_time = clazz.new(2020, 9, 15)
 
               expect(TimeDifference.between(start_time, end_time).in_months.round(1)).to eql(18.0)
+            end
+
+            it 'returns 18.5' do
+              start_time = clazz.new(2019, 3, 15)
+              end_time = clazz.new(2020, 9, 30)
+
+              expect(TimeDifference.between(start_time, end_time).in_months.round(1)).to eql(18.5)
             end
 
             it 'returns 24.0' do

--- a/spec/time_difference_spec.rb
+++ b/spec/time_difference_spec.rb
@@ -378,50 +378,6 @@ describe TimeDifference do
           end
         end
       end
-
-
-
-
-
-
-
-      # it "returns time difference in months based on Wolfram Alpha" do
-      #   start_time = clazz.new(2011, 1)
-      #   end_time = clazz.new(2011, 12)
-
-      #   expect(TimeDifference.between(start_time, end_time).in_months).to eql(10.98)
-      # end
-
-      # it "returns an absolute difference" do
-      #   start_time = clazz.new(2011, 12)
-      #   end_time = clazz.new(2011, 1)
-
-      #   expect(TimeDifference.between(start_time, end_time).in_months).to eql(10.98)
-      # end
-
-      # context "in a leap year" do
-      #   it "adds an extra day to cover 29th February" do
-      #     start_time = clazz.new(2012, 1)
-      #     end_time = clazz.new(2012, 3)
-
-      #     expect(TimeDifference.between(start_time, end_time).in_months).to eql(2.01)
-      #   end
-
-      #   it "does not add an extra day if the difference is within the 29th February" do
-      #     start_time = clazz.new(2012, 2, 29, 1)
-      #     end_time = clazz.new(2012, 2, 29, 2)
-
-      #     expect(TimeDifference.between(start_time, end_time).in_months).to eql(0.0)
-      #   end
-
-      #   it "doesn't add a day when the date period does not cover 29th February" do
-      #     start_time = clazz.new(2012, 3, 27)
-      #     end_time = clazz.new(2012, 4, 27)
-
-      #     expect(TimeDifference.between(start_time, end_time).in_months).to eql(1.02)
-      #   end
-
-      # end
     end
   end
 

--- a/spec/time_difference_spec.rb
+++ b/spec/time_difference_spec.rb
@@ -63,6 +63,131 @@ describe TimeDifference do
 
   describe "#in_months" do
     with_each_class do |clazz|
+      context '1 whole month between dates' do
+        context 'start_time is before end_time' do
+          context 'normal year' do
+            it 'returns 1.0' do
+              start_time = clazz.new(2019, 1, 1)
+              end_time = clazz.new(2019, 2, 1)
+
+              expect(TimeDifference.between(start_time, end_time).in_months.round(2)).to eql(1.00)
+            end
+
+            it 'returns 1.0' do
+              start_time = clazz.new(2019, 2, 1)
+              end_time = clazz.new(2019, 3, 1)
+
+              expect(TimeDifference.between(start_time, end_time).in_months.round(2)).to eql(1.00)
+            end
+
+            it 'returns 1.0' do
+              start_time = clazz.new(2019, 1, 15)
+              end_time = clazz.new(2019, 2, 15)
+
+              expect(TimeDifference.between(start_time, end_time).in_months.round(2)).to eql(1.00)
+            end
+
+            it 'returns 1.0' do
+              start_time = clazz.new(2019, 12, 15)
+              end_time = clazz.new(2020, 1, 15)
+
+              expect(TimeDifference.between(start_time, end_time).in_months.round(2)).to eql(1.00)
+            end
+
+            it 'returns 1.0' do
+              start_time = clazz.new(2019, 9, 15)
+              end_time = clazz.new(2019, 8, 15)
+
+              expect(TimeDifference.between(start_time, end_time).in_months.round(2)).to eql(1.00)
+            end
+          end
+
+          context 'leap year' do
+            it 'returns 1.0' do
+              start_time = clazz.new(2020, 1, 1)
+              end_time = clazz.new(2020, 2, 1)
+
+              expect(TimeDifference.between(start_time, end_time).in_months.round(2)).to eql(1.00)
+            end
+
+            it 'returns 1.0' do
+              start_time = clazz.new(2020, 2, 1)
+              end_time = clazz.new(2020, 3, 1)
+
+              expect(TimeDifference.between(start_time, end_time).in_months.round(2)).to eql(1.00)
+            end
+
+            it 'returns 1.0' do
+              start_time = clazz.new(2020, 2, 15)
+              end_time = clazz.new(2020, 3, 15)
+
+              expect(TimeDifference.between(start_time, end_time).in_months.round(2)).to eql(1.00)
+            end
+
+            it 'returns 1.0' do
+              start_time = clazz.new(2020, 9, 19)
+              end_time = clazz.new(2020, 10, 19)
+
+              expect(TimeDifference.between(start_time, end_time).in_months.round(2)).to eql(1.00)
+            end
+
+            it 'returns 1.0' do
+              start_time = clazz.new(2020, 2, 29)
+              end_time = clazz.new(2020, 3, 29)
+
+              expect(TimeDifference.between(start_time, end_time).in_months.round(2)).to eql(1.00)
+            end
+          end
+        end
+
+        context 'end_time is before start_time' do
+          context 'normal year' do
+            it 'returns 1.0' do
+              start_time = clazz.new(2019, 2, 1)
+              end_time = clazz.new(2019, 1, 1)
+
+              expect(TimeDifference.between(start_time, end_time).in_months.round(2)).to eql(1.00)
+            end
+
+            it 'returns 1.0' do
+              start_time = clazz.new(2019, 9, 12)
+              end_time = clazz.new(2019, 8, 12)
+
+              expect(TimeDifference.between(start_time, end_time).in_months.round(2)).to eql(1.00)
+            end
+
+            it 'returns 1.0' do
+              start_time = clazz.new(2020, 1, 20)
+              end_time = clazz.new(2019, 12, 20)
+
+              expect(TimeDifference.between(start_time, end_time).in_months.round(2)).to eql(1.00)
+            end
+          end
+
+          context 'leap year' do
+            it 'returns 1.0' do
+              start_time = clazz.new(2020, 9, 12)
+              end_time = clazz.new(2020, 8, 12)
+
+              expect(TimeDifference.between(start_time, end_time).in_months.round(2)).to eql(1.00)
+            end
+
+            it 'returns 1.0' do
+              start_time = clazz.new(2020, 3, 15)
+              end_time = clazz.new(2020, 2, 15)
+
+              expect(TimeDifference.between(start_time, end_time).in_months.round(2)).to eql(1.00)
+            end
+          end
+        end
+      end
+
+
+
+
+
+
+
       it "returns time difference in months based on Wolfram Alpha" do
         start_time = clazz.new(2011, 1)
         end_time = clazz.new(2011, 12)

--- a/spec/time_difference_spec.rb
+++ b/spec/time_difference_spec.rb
@@ -98,6 +98,7 @@ describe TimeDifference do
 
           expect(TimeDifference.between(start_time, end_time).in_months).to eql(1.02)
         end
+
       end
     end
   end
@@ -134,6 +135,22 @@ describe TimeDifference do
         end_time = clazz.new(2011, 1)
 
         expect(TimeDifference.between(start_time, end_time).in_days).to eql(334.0)
+      end
+
+      context "it's a leap year" do
+        it 'calculates the correct number of days when not including 29th February' do
+          start_time = clazz.new(2020, 2, 26)
+          end_time = clazz.new(2020, 2, 28)
+
+          expect(TimeDifference.between(start_time, end_time).in_days).to eql(2.0)
+        end
+
+        it 'calculates the correct number of days including 29th February' do
+          start_time = clazz.new(2020, 2, 28)
+          end_time = clazz.new(2020, 3, 1)
+
+          expect(TimeDifference.between(start_time, end_time).in_days).to eql(2.0)
+        end
       end
     end
   end

--- a/spec/time_difference_spec.rb
+++ b/spec/time_difference_spec.rb
@@ -70,35 +70,35 @@ describe TimeDifference do
               start_time = clazz.new(2019, 1, 1)
               end_time = clazz.new(2019, 2, 1)
 
-              expect(TimeDifference.between(start_time, end_time).in_months.round(2)).to eql(1.00)
+              expect(TimeDifference.between(start_time, end_time).in_months.round(1)).to eql(1.0)
             end
 
             it 'returns 1.0' do
               start_time = clazz.new(2019, 2, 1)
               end_time = clazz.new(2019, 3, 1)
 
-              expect(TimeDifference.between(start_time, end_time).in_months.round(2)).to eql(1.00)
+              expect(TimeDifference.between(start_time, end_time).in_months.round(1)).to eql(1.0)
             end
 
             it 'returns 1.0' do
               start_time = clazz.new(2019, 1, 15)
               end_time = clazz.new(2019, 2, 15)
 
-              expect(TimeDifference.between(start_time, end_time).in_months.round(2)).to eql(1.00)
+              expect(TimeDifference.between(start_time, end_time).in_months.round(1)).to eql(1.0)
             end
 
             it 'returns 1.0' do
               start_time = clazz.new(2019, 12, 15)
               end_time = clazz.new(2020, 1, 15)
 
-              expect(TimeDifference.between(start_time, end_time).in_months.round(2)).to eql(1.00)
+              expect(TimeDifference.between(start_time, end_time).in_months.round(1)).to eql(1.0)
             end
 
             it 'returns 1.0' do
               start_time = clazz.new(2019, 9, 15)
               end_time = clazz.new(2019, 8, 15)
 
-              expect(TimeDifference.between(start_time, end_time).in_months.round(2)).to eql(1.00)
+              expect(TimeDifference.between(start_time, end_time).in_months.round(1)).to eql(1.0)
             end
           end
 
@@ -107,35 +107,35 @@ describe TimeDifference do
               start_time = clazz.new(2020, 1, 1)
               end_time = clazz.new(2020, 2, 1)
 
-              expect(TimeDifference.between(start_time, end_time).in_months.round(2)).to eql(1.00)
+              expect(TimeDifference.between(start_time, end_time).in_months.round(1)).to eql(1.0)
             end
 
             it 'returns 1.0' do
               start_time = clazz.new(2020, 2, 1)
               end_time = clazz.new(2020, 3, 1)
 
-              expect(TimeDifference.between(start_time, end_time).in_months.round(2)).to eql(1.00)
+              expect(TimeDifference.between(start_time, end_time).in_months.round(1)).to eql(1.0)
             end
 
             it 'returns 1.0' do
               start_time = clazz.new(2020, 2, 15)
               end_time = clazz.new(2020, 3, 15)
 
-              expect(TimeDifference.between(start_time, end_time).in_months.round(2)).to eql(1.00)
+              expect(TimeDifference.between(start_time, end_time).in_months.round(1)).to eql(1.0)
             end
 
             it 'returns 1.0' do
               start_time = clazz.new(2020, 9, 19)
               end_time = clazz.new(2020, 10, 19)
 
-              expect(TimeDifference.between(start_time, end_time).in_months.round(2)).to eql(1.00)
+              expect(TimeDifference.between(start_time, end_time).in_months.round(1)).to eql(1.0)
             end
 
             it 'returns 1.0' do
               start_time = clazz.new(2020, 2, 29)
               end_time = clazz.new(2020, 3, 29)
 
-              expect(TimeDifference.between(start_time, end_time).in_months.round(2)).to eql(1.00)
+              expect(TimeDifference.between(start_time, end_time).in_months.round(1)).to eql(1.0)
             end
           end
         end
@@ -146,21 +146,21 @@ describe TimeDifference do
               start_time = clazz.new(2019, 2, 1)
               end_time = clazz.new(2019, 1, 1)
 
-              expect(TimeDifference.between(start_time, end_time).in_months.round(2)).to eql(1.00)
+              expect(TimeDifference.between(start_time, end_time).in_months.round(1)).to eql(1.0)
             end
 
             it 'returns 1.0' do
               start_time = clazz.new(2019, 9, 12)
               end_time = clazz.new(2019, 8, 12)
 
-              expect(TimeDifference.between(start_time, end_time).in_months.round(2)).to eql(1.00)
+              expect(TimeDifference.between(start_time, end_time).in_months.round(1)).to eql(1.0)
             end
 
             it 'returns 1.0' do
               start_time = clazz.new(2020, 1, 20)
               end_time = clazz.new(2019, 12, 20)
 
-              expect(TimeDifference.between(start_time, end_time).in_months.round(2)).to eql(1.00)
+              expect(TimeDifference.between(start_time, end_time).in_months.round(1)).to eql(1.0)
             end
           end
 
@@ -169,14 +169,211 @@ describe TimeDifference do
               start_time = clazz.new(2020, 9, 12)
               end_time = clazz.new(2020, 8, 12)
 
-              expect(TimeDifference.between(start_time, end_time).in_months.round(2)).to eql(1.00)
+              expect(TimeDifference.between(start_time, end_time).in_months.round(1)).to eql(1.0)
             end
 
             it 'returns 1.0' do
               start_time = clazz.new(2020, 3, 15)
               end_time = clazz.new(2020, 2, 15)
 
-              expect(TimeDifference.between(start_time, end_time).in_months.round(2)).to eql(1.00)
+              expect(TimeDifference.between(start_time, end_time).in_months.round(1)).to eql(1.0)
+            end
+          end
+        end
+      end
+
+      context 'start_time and end_time are in different years' do
+        context 'start_time is before end_time' do
+          context 'does not include a leap year' do
+            it 'returns 12.0' do
+              start_time = clazz.new(2018, 3, 15)
+              end_time = clazz.new(2019, 3, 15)
+
+              expect(TimeDifference.between(start_time, end_time).in_months.round(1)).to eql(12.0)
+            end
+
+            it 'returns 18.0' do
+              start_time = clazz.new(2018, 3, 15)
+              end_time = clazz.new(2019, 9, 15)
+
+              expect(TimeDifference.between(start_time, end_time).in_months.round(1)).to eql(18.0)
+            end
+
+            it 'returns 24.0' do
+              start_time = clazz.new(2017, 3, 15)
+              end_time = clazz.new(2019, 3, 15)
+
+              expect(TimeDifference.between(start_time, end_time).in_months.round(1)).to eql(24.0)
+            end
+
+            it 'returns 36.0' do
+              start_time = clazz.new(2016, 3, 15)
+              end_time = clazz.new(2019, 3, 15)
+
+              expect(TimeDifference.between(start_time, end_time).in_months.round(1)).to eql(36.0)
+            end
+          end
+
+          context 'includes a leap year' do
+            it 'returns 12.0' do
+              start_time = clazz.new(2019, 3, 15)
+              end_time = clazz.new(2020, 3, 15)
+
+              expect(TimeDifference.between(start_time, end_time).in_months.round(1)).to eql(12.0)
+            end
+
+            it 'returns 18.0' do
+              start_time = clazz.new(2019, 3, 15)
+              end_time = clazz.new(2020, 9, 15)
+
+              expect(TimeDifference.between(start_time, end_time).in_months.round(1)).to eql(18.0)
+            end
+
+            it 'returns 24.0' do
+              start_time = clazz.new(2018, 3, 15)
+              end_time = clazz.new(2020, 3, 15)
+
+              expect(TimeDifference.between(start_time, end_time).in_months.round(1)).to eql(24.0)
+            end
+
+            it 'returns 24.0' do
+              start_time = clazz.new(2019, 3, 15)
+              end_time = clazz.new(2021, 3, 15)
+
+              expect(TimeDifference.between(start_time, end_time).in_months.round(1)).to eql(24.0)
+            end
+
+            it 'returns 36.0' do
+              start_time = clazz.new(2017, 3, 15)
+              end_time = clazz.new(2020, 3, 15)
+
+              expect(TimeDifference.between(start_time, end_time).in_months.round(1)).to eql(36.0)
+            end
+
+            it 'returns 36.0' do
+              start_time = clazz.new(2018, 3, 15)
+              end_time = clazz.new(2021, 3, 15)
+
+              expect(TimeDifference.between(start_time, end_time).in_months.round(1)).to eql(36.0)
+            end
+
+            it 'returns 36.0' do
+              start_time = clazz.new(2020, 3, 15)
+              end_time = clazz.new(2023, 3, 15)
+
+              expect(TimeDifference.between(start_time, end_time).in_months.round(1)).to eql(36.0)
+            end
+          end
+        end
+
+        context 'end_time is before start_time' do
+          context 'does not include a leap year' do
+            it 'returns 12.0' do
+              start_time = clazz.new(2019, 3, 15)
+              end_time = clazz.new(2018, 3, 15)
+
+              expect(TimeDifference.between(start_time, end_time).in_months.round(1)).to eql(12.0)
+            end
+
+            it 'returns 18.0' do
+              start_time = clazz.new(2019, 9, 15)
+              end_time = clazz.new(2018, 3, 15)
+
+              expect(TimeDifference.between(start_time, end_time).in_months.round(1)).to eql(18.0)
+            end
+
+            it 'returns 24.0' do
+              start_time = clazz.new(2019, 3, 15)
+              end_time = clazz.new(2017, 3, 15)
+
+              expect(TimeDifference.between(start_time, end_time).in_months.round(1)).to eql(24.0)
+            end
+
+            it 'returns 36.0' do
+              start_time = clazz.new(2019, 3, 15)
+              end_time = clazz.new(2016, 3, 15)
+
+              expect(TimeDifference.between(start_time, end_time).in_months.round(1)).to eql(36.0)
+            end
+          end
+
+          context 'includes a leap year' do
+            it 'returns 12.0' do
+              start_time = clazz.new(2020, 3, 15)
+              end_time = clazz.new(2019, 3, 15)
+
+              expect(TimeDifference.between(start_time, end_time).in_months.round(1)).to eql(12.0)
+            end
+
+            it 'returns 24.0' do
+              start_time = clazz.new(2020, 3, 15)
+              end_time = clazz.new(2018, 3, 15)
+
+              expect(TimeDifference.between(start_time, end_time).in_months.round(1)).to eql(24.0)
+            end
+
+            it 'returns 36.0' do
+              start_time = clazz.new(2020, 3, 15)
+              end_time = clazz.new(2017, 3, 15)
+
+              expect(TimeDifference.between(start_time, end_time).in_months.round(1)).to eql(36.0)
+            end
+          end
+        end
+      end
+
+      context 'start_time and end_time are in the same month and same year' do
+        context 'start_time is before end_time' do
+          context 'normal year' do
+            it 'returns 0.5' do
+              start_time = clazz.new(2019, 4, 15)
+              end_time = clazz.new(2019, 4, 30)
+
+              expect(TimeDifference.between(start_time, end_time).in_months.round(2)).to eql(0.5)
+            end
+
+            it 'returns 0.5' do
+              start_time = clazz.new(2019, 4, 1)
+              end_time = clazz.new(2019, 4, 15)
+
+              expect(TimeDifference.between(start_time, end_time).in_months.round(2)).to eql(0.5)
+            end
+
+            it 'returns 0.97' do
+              start_time = clazz.new(2019, 4, 1)
+              end_time = clazz.new(2019, 4, 30)
+
+              expect(TimeDifference.between(start_time, end_time).in_months.round(2)).to eql(0.97)
+            end
+
+            it 'returns 0.33' do
+              start_time = clazz.new(2019, 4, 1)
+              end_time = clazz.new(2019, 4, 11)
+
+              expect(TimeDifference.between(start_time, end_time).in_months.round(2)).to eql(0.33)
+            end
+
+            it '1st to 28th February returns 0.96' do
+              start_time = clazz.new(2019, 2, 1)
+              end_time = clazz.new(2019, 2, 28)
+
+              expect(TimeDifference.between(start_time, end_time).in_months.round(2)).to eql(0.96)
+            end
+          end
+
+          context 'leap year' do
+            it '1st to 28th February returns 0.93' do
+              start_time = clazz.new(2020, 2, 1)
+              end_time = clazz.new(2020, 2, 28)
+
+              expect(TimeDifference.between(start_time, end_time).in_months.round(2)).to eql(0.93)
+            end
+
+            it '1st to 29th February returns 0.97' do
+              start_time = clazz.new(2020, 2, 1)
+              end_time = clazz.new(2020, 2, 29)
+
+              expect(TimeDifference.between(start_time, end_time).in_months.round(2)).to eql(0.97)
             end
           end
         end
@@ -188,43 +385,43 @@ describe TimeDifference do
 
 
 
-      it "returns time difference in months based on Wolfram Alpha" do
-        start_time = clazz.new(2011, 1)
-        end_time = clazz.new(2011, 12)
+      # it "returns time difference in months based on Wolfram Alpha" do
+      #   start_time = clazz.new(2011, 1)
+      #   end_time = clazz.new(2011, 12)
 
-        expect(TimeDifference.between(start_time, end_time).in_months).to eql(10.98)
-      end
+      #   expect(TimeDifference.between(start_time, end_time).in_months).to eql(10.98)
+      # end
 
-      it "returns an absolute difference" do
-        start_time = clazz.new(2011, 12)
-        end_time = clazz.new(2011, 1)
+      # it "returns an absolute difference" do
+      #   start_time = clazz.new(2011, 12)
+      #   end_time = clazz.new(2011, 1)
 
-        expect(TimeDifference.between(start_time, end_time).in_months).to eql(10.98)
-      end
+      #   expect(TimeDifference.between(start_time, end_time).in_months).to eql(10.98)
+      # end
 
-      context "in a leap year" do
-        it "adds an extra day to cover 29th February" do
-          start_time = clazz.new(2012, 1)
-          end_time = clazz.new(2012, 3)
+      # context "in a leap year" do
+      #   it "adds an extra day to cover 29th February" do
+      #     start_time = clazz.new(2012, 1)
+      #     end_time = clazz.new(2012, 3)
 
-          expect(TimeDifference.between(start_time, end_time).in_months).to eql(2.01)
-        end
+      #     expect(TimeDifference.between(start_time, end_time).in_months).to eql(2.01)
+      #   end
 
-        it "does not add an extra day if the difference is within the 29th February" do
-          start_time = clazz.new(2012, 2, 29, 1)
-          end_time = clazz.new(2012, 2, 29, 2)
+      #   it "does not add an extra day if the difference is within the 29th February" do
+      #     start_time = clazz.new(2012, 2, 29, 1)
+      #     end_time = clazz.new(2012, 2, 29, 2)
 
-          expect(TimeDifference.between(start_time, end_time).in_months).to eql(0.0)
-        end
+      #     expect(TimeDifference.between(start_time, end_time).in_months).to eql(0.0)
+      #   end
 
-        it "doesn't add a day when the date period does not cover 29th February" do
-          start_time = clazz.new(2012, 3, 27)
-          end_time = clazz.new(2012, 4, 27)
+      #   it "doesn't add a day when the date period does not cover 29th February" do
+      #     start_time = clazz.new(2012, 3, 27)
+      #     end_time = clazz.new(2012, 4, 27)
 
-          expect(TimeDifference.between(start_time, end_time).in_months).to eql(1.02)
-        end
+      #     expect(TimeDifference.between(start_time, end_time).in_months).to eql(1.02)
+      #   end
 
-      end
+      # end
     end
   end
 


### PR DESCRIPTION
Update the `in_months` method to use the number of days in a month, rather than just 30.42 days for _every_ month.

This was problematic because it did not add an extra day for leap years, and the existing fix was breaking other methods, for example `28/02/2020` -> `01/03/2020` `in_days` was returning 3 days, where as it should be two. I've now removed that fix.
The other problem was that assuming every month to be 30.42 days meant that in months of <= 30 days, it would return < 1, and I encountered some code that was using `in_months.floor`, which with, for example, `01/04/2019` -> `01/05/2019` would yield `0`.
What this update does, is use the exact number of days in a month to calculate any partial months. For example `01/02/2019` -> `06/02/2019` will now be calculated at `5/28` (rather than `5/30.42`), and full months will always return `1.0`. For example `01/02/2019` -> `01/03/2019` will now return `1.0`, where as before it would have been `0.92` (28/30.42).

There's a safeguard in place so that for example `15/02/2019` -> `16/03/2019` (13/28 + 16/30 = 0.99) will instead yield one full month, plus 1/30 (so 1.03). This ensures that `15/02/2019` -> `16/03/2019` will never yield less than `15/02/2019` -> `15/03/2019`.

Note that there is a failing spec. This is also failing in master, and in the leap-years branch and is related to the `in_general` method.